### PR TITLE
improvement: server dotenv and config reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 The git log should show a fairly clean view of each of these new versions, and the issues/PRs associated.
 
+# 0.3.8
+
+- require `dotenv` in the server runtime (for loading graphql config values), and allow a `graphql-config.dotEnvPath` configuration to specify specific paths
+- reload server on workspace configuration changes
+- reload severside `graphql-config` and language service on config file changes. definitions cache/etc will be rebuilt
+  - note: client not configured to reload on graphql config changes yet (i.e endpoints)
+- accept all `graphql-config.loadConfig()` options
+
 # 0.3.7
 
 - update underlying `graphql-language-service-server` to allow .gql, .graphqls extensions

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ GraphQL extension VSCode built with the aim to tightly integrate the GraphQL Eco
 
 ![](https://camo.githubusercontent.com/97dc1080d5e6883c4eec3eaa6b7d0f29802e6b4b/687474703a2f2f672e7265636f726469742e636f2f497379504655484e5a342e676966)
 
-> 💡 **Note:** This extension no longer supports `.prisma` files. If you are using this extension with Prisma 1, please rename your datamodel from `datamodel.prisma` to `datamodel.graphql` and this extension will pick that up.
+> 💡 **Note:** This extension no longer supports `.prisma` files. If you are using this extension with GraphQL 1, please rename your datamodel from `datamodel.prisma` to `datamodel.graphql` and this extension will pick that up.
 
 ## Features
+
+Lots of new improvements happening! We now have a [`CHANGELOG.md`](https://github.com/graphql/vscode-graphql/blob/master/CHANGELOG.md#change-log)
 
 ### General features
 
@@ -16,6 +18,7 @@ GraphQL extension VSCode built with the aim to tightly integrate the GraphQL Eco
 - execute query/mutation/subscription operation, embedded or in graphql files
 - pre-load schema and document defintitions
 - Support [`graphql-config`](https://graphql-config.com/) files with one project and multiple projects
+- the language service re-starts on changes to vscode settings and/or graphql config!
 
 ### `.graphql`, `.gql` file extension support
 
@@ -39,7 +42,7 @@ GraphQL extension VSCode built with the aim to tightly integrate the GraphQL Eco
 
 ## Usage
 
-Install the [VSCode GraphQL Extension](https://marketplace.visualstudio.com/items?itemName=Prisma.vscode-graphql).
+Install the [VSCode GraphQL Extension](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql).
 
 (Watchman is no longer required, you can uninstall it now)
 
@@ -218,14 +221,14 @@ const myQuery = `
 
 ## Known Issues
 
-- template replacement inside a graphql string [will break graphql parsing](https://github.com/prisma-labs/vscode-graphql/issues/137). If you want to help improve partial parsing support, you can contribute to the parser efforts in [`graphql`](https://github.com/graphql/graphql-js) reference implementation. You can now re-use fragments across your project source, if you include the files in `documents`.
+- template replacement inside a graphql string [will break graphql parsing](https://github.com/graphql/vscode-graphql/issues/137). If you want to help improve partial parsing support, you can contribute to the parser efforts in [`graphql`](https://github.com/graphql/graphql-js) reference implementation. You can now re-use fragments across your project source, if you include the files in `documents`.
 - the output channel occasionally shows "definition not found" when you first start the language service, but once the definition cache is built for each project, definition lookup will work. so if a "peek definition" fails when you first start, just try clicking it again.
 
 ## Development
 
 This plugin uses the [GraphQL language server](https://github.com/graphql/graphql-language-service-server)
 
-1.  Clone the repository - https://github.com/prisma-labs/vscode-graphql
+1.  Clone the repository - https://github.com/graphql/vscode-graphql
 1.  `npm install`
 1.  Open it in VSCode
 1.  Go to the debugging section and run the launch program "Extension"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,11 +1119,12 @@
       }
     },
     "graphql-language-service-server": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-server/-/graphql-language-service-server-2.5.2.tgz",
-      "integrity": "sha512-oZNLHBAhMlkFi/x697eMSq5y+WJB1p5u3WhAS6P+fBGusZiydpSKefLy0KXz4A4ym52jtM4llIankWSjRW+iNA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-server/-/graphql-language-service-server-2.5.3.tgz",
+      "integrity": "sha512-18OQTK8AH/DVvznyD3xQfTdd5ckC7bsdKc9E4BHzscwFuqjLRz/xSwx09OejR//oKdwRtlcqYOXlB+G+3lQtcw==",
       "requires": {
         "@babel/parser": "^7.9.0",
+        "dotenv": "8.2.0",
         "glob": "^7.1.2",
         "graphql-config": "^3.0.3",
         "graphql-language-service": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   "icon": "assets/images/logo.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma-labs/vscode-graphql"
+    "url": "https://github.com/graphql/vscode-graphql"
   },
-  "homepage": "https://github.com/prisma-labs/vscode-graphql/blob/master/README.md",
+  "homepage": "https://github.com/graphql/vscode-graphql/blob/master/README.md",
   "galleryBanner": {
     "color": "#032539",
     "theme": "dark"
   },
-  "publisher": "Prisma",
+  "publisher": "GraphQL",
   "engines": {
     "vscode": "^1.32.0"
   },
@@ -119,8 +119,7 @@
           "type": [
             "string"
           ],
-          "description": "Base dir for graphql config loadConfig()",
-          "default": null
+          "description": "Base dir for graphql config loadConfig()"
         },
         "graphql-config.load.filePath": {
           "type": [
@@ -142,20 +141,27 @@
           ],
           "description": "optional <configName>.config.js instead of default `graphql`",
           "default": null
+        },
+        "graphql-config.dotEnvPath": {
+          "type": [
+            "string"
+          ],
+          "description": "optional .env load path, if not the default",
+          "default": null
         }
       }
     },
     "commands": [
       {
-        "command": "extension.isDebugging",
+        "command": "vscode-graphql.isDebugging",
         "title": "VSCode GraphQL - Is Debugging?"
       },
       {
-        "command": "extension.restart",
-        "title": "VSCode GraphQL - Restart"
+        "command": "vscode-graphql.restart",
+        "title": "VSCode GraphQL - Manual Restart"
       },
       {
-        "command": "extension.contentProvider",
+        "command": "vscode-graphql.contentProvider",
         "title": "Execute GraphQL Operations"
       }
     ]
@@ -196,7 +202,7 @@
     "dotenv": "^8.2.0",
     "graphql": "^15.3.0",
     "graphql-config": "^3.0.3",
-    "graphql-language-service-server": "^2.5.2",
+    "graphql-language-service-server": "^2.5.3",
     "graphql-tag": "^2.11.0",
     "node-fetch": "^2.6.0",
     "ovsx": "0.1.0-next.dacd2fd",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,7 @@ export async function activate(context: ExtensionContext) {
     ],
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher(
-        "**/*.{graphql,graphqls,gql,js,jsx,ts,tsx}",
+        "**/{*.graphql,*.graphqls,*.gql,*.js,*.jsx,*.ts,*.tsx,graphql.config.*,.graphqlrc,.graphqlrc.*,package.json}",
       ),
     },
     outputChannel: outputChannel,


### PR DESCRIPTION
- updates for transfer from Prisma > GraphQL
- require `dotenv` in the server runtime (for loading graphql config values), and allow a `graphql-config.dotEnvPath` configuration to specify specific paths
- reload server on workspace configuration changes
- reload severside `graphql-config` and language service on config file changes. definitions cache/etc will be rebuilt
  - note: client not configured to reload on graphql config changes yet (i.e endpoints)
- accept all `graphql-config.loadConfig()` options