### PR TITLE
feat: support highlighting markdown fenced code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Lots of new improvements happening! We now have a [`CHANGELOG.md`](https://githu
 - Load the extension on detecting `graphql-config file` at root level or in a parent level directory
 - Load the extension in `.graphql`, `.gql files`
 - Load the extension on detecting `gql` tag in js, ts, jsx, tsx, vue files
+- Load the extension inside `gql`/`graphql` fenced code blocks in markdown files
 - execute query/mutation/subscription operation, embedded or in graphql files
 - pre-load schema and document defintitions
 - Support [`graphql-config`](https://graphql-config.com/) files with one project and multiple projects

--- a/grammars/graphql.markdown.codeblock.json
+++ b/grammars/graphql.markdown.codeblock.json
@@ -1,0 +1,23 @@
+{
+  "fileTypes": [],
+  "scopeName": "markdown.graphql.codeblock",
+  "injectionSelector": "L:markup.fenced_code.block.markdown",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(gql|graphql|GraphQL)(\\s+[^`~]*)?$",
+      "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "patterns": [
+            {
+              "include": "source.graphql"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.graphql": "graphql"
         }
+      },
+      {
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "scopeName": "markdown.graphql.codeblock",
+        "path": "./grammars/graphql.markdown.codeblock.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "snippets": [


### PR DESCRIPTION
Closes https://github.com/graphql/vscode-graphql/issues/78

Contributes to https://github.com/graphql/vscode-graphql/issues/138

This adds support for highlighting of markdown fenced code blocks, e.g.:
```md
 ```gql
 ```graphql
```
