### PR TITLE
docs: fix typo in simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To support language features like "go-to definition" across multiple files, plea
 ```js
 // .graphqlrc.yml
 schema: "schema.graphql"
-documents: "src/**/*.{graphql,js,ts,jsx,tsx"
+documents: "src/**/*.{graphql,js,ts,jsx,tsx}"
 ```
 
 ### Advanced Example


### PR DESCRIPTION
It's a small thing in the readme, but a big issue for inexperienced users like me 😅 (took me 15 min to realize this 🙈 )