### PR TITLE
Fix dotenv issues

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,11 @@ export async function activate(context: ExtensionContext) {
   const config = getConfig()
   const { debug } = config
 
+  // Set cwd to workspace so .env files load properly
+  if (workspace.workspaceFolders) {
+    process.chdir(workspace.workspaceFolders[0].uri.fsPath)
+  }
+
   if (debug) {
     console.log('Extension "vscode-graphql" is now active!')
   }


### PR DESCRIPTION
Fixes #257

I don't know two licks about vscode extension development, but this was bugging me and I wanted to take a swing at debugging this. `workspaceFolders[0]` must contain the proper env file at activation time.. perhaps you could make this path configurable instead.

Don't have the time to debug further, but I think what's happening is either `graphql-config` or `cosmiconfig` are loading the env once and for the `cwd`. However, the extension is running with cwd at `/`, so no env is loaded.
