### PR TITLE
fix: 'Execute Query' below gql` is shown one line down

### DIFF
--- a/src/client/graphql-codelens-provider.ts
+++ b/src/client/graphql-codelens-provider.ts
@@ -31,8 +31,8 @@ export class GraphQLCodeLensProvider implements CodeLensProvider {
     return literals.map(literal => {
       return new CodeLens(
         new Range(
-          new Position(literal.position.line + 1, 0),
-          new Position(literal.position.line + 1, 0),
+          new Position(literal.position.line, 0),
+          new Position(literal.position.line, 0),
         ),
         {
           title: `Execute ${capitalize(literal.definition.operation)}`,

--- a/src/client/source-helper.ts
+++ b/src/client/source-helper.ts
@@ -60,26 +60,26 @@ export class SourceHelper {
           if (parseInt(value)) {
             return null
           }
-          break;
+          break
         case "Float":
           if (parseFloat(value)) {
             return null
           }
-          break;
+          break
         case "Boolean":
           if (value === "true" || value === "false") {
             return null
           }
-          break;
+          break
         case "String":
           if (value.length && !Array.isArray(value)) {
             return null
           }
-          break;
+          break
         default:
           // For scalar types, it is impossible to know what data type they
           // should be. Therefore we don't do any validation.
-          return null;
+          return null
       }
     } catch {
       return `${value} is not a valid ${type}`
@@ -164,7 +164,7 @@ export class SourceHelper {
       // https://regex101.com/r/Pd5PaU/2
       const regExpGQL = new RegExp(tag + "\\s*`([\\s\\S]+?)`", "mg")
 
-      let result
+      let result: RegExpExecArray | null
       while ((result = regExpGQL.exec(text)) !== null) {
         const contents = result[1]
 
@@ -174,7 +174,7 @@ export class SourceHelper {
           continue
         }
         try {
-          processGraphQLString(contents, result.index + 4)
+          processGraphQLString(contents, result.index + tag.length + 1)
         } catch (e) {}
       }
     })


### PR DESCRIPTION
'Execute Query' below ``gql` `` is shown one line down.

Expected behavior:
![image](https://user-images.githubusercontent.com/46275902/106002607-aca95f80-60f4-11eb-8fc8-3e0bc46d14dd.png)

Actual:
![image](https://user-images.githubusercontent.com/46275902/106002461-84216580-60f4-11eb-884f-76bf3898c71f.png)
