### PR TITLE
feat: provide 'Execute Query' for /* GraphQL */ templates

### DIFF
--- a/.changeset/silver-radios-invent.md
+++ b/.changeset/silver-radios-invent.md
@@ -1,0 +1,5 @@
+---
+"vscode-graphql": patch
+---
+
+provide 'Execute Query' for `/* GraphQL */` templates

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "env:source": "export $(cat .envrc | xargs)",
     "vsce:publish": "vsce publish",
     "open-vsx:publish": "ovsx publish -p \"$OPEN_VSX_ACCESS_TOKEN\"",
-    "publish": "vsce:publish && open-vsx:publish",
+    "publish": "npm run vsce:publish && npm run open-vsx:publish",
     "upgrade-interactive": "npx npm-check -u"
   },
   "devDependencies": {

--- a/src/client/graphql-codelens-provider.ts
+++ b/src/client/graphql-codelens-provider.ts
@@ -6,6 +6,7 @@ import {
   CodeLens,
   Range,
   Position,
+  ProviderResult,
 } from "vscode"
 
 import { SourceHelper, ExtractedTemplateLiteral } from "./source-helper"
@@ -23,10 +24,14 @@ export class GraphQLCodeLensProvider implements CodeLensProvider {
   public provideCodeLenses(
     document: TextDocument,
     _token: CancellationToken,
-  ): CodeLens[] {
-    const literals: ExtractedTemplateLiteral[] =
-      this.sourceHelper.extractAllTemplateLiterals(document, ["gql", "graphql"])
-    return literals.map(literal => {
+    // for some reason, ProviderResult<CodeLens[]> doesn't work here
+    // anymore after upgrading types
+  ): ProviderResult<[]> {
+    const literals: ExtractedTemplateLiteral[] = this.sourceHelper.extractAllTemplateLiterals(
+      document,
+      ["gql", "graphql", "/\\* GraphQL \\*/"],
+    )
+    const results = literals.map(literal => {
       return new CodeLens(
         new Range(
           new Position(literal.position.line, 0),
@@ -39,5 +44,7 @@ export class GraphQLCodeLensProvider implements CodeLensProvider {
         },
       )
     })
+
+    return results as ProviderResult<[]>
   }
 }


### PR DESCRIPTION
It partially fixes #232.
(Completions still don't work; we may need to fix graphql-language-service-server.)

![image](https://user-images.githubusercontent.com/46275902/106010625-001fab80-60fd-11eb-90d0-1001bc36de2c.png)
