### PR TITLE
Enable in vue files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Lots of new improvements happening! We now have a [`CHANGELOG.md`](https://githu
 - go to definition support (input, enum, type)
 - outline support
 
-### `gql`/`graphql` tagged template literal support for tsx, jsx, ts, js
+### `gql`/`graphql` tagged template literal support for tsx, jsx, ts, js, vue
 
 - syntax highlighting (type, query, mutation, interface, union, enum, scalar, fragments, directives)
 - autocomplete suggestions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,6 +70,8 @@ export function activate(context: ExtensionContext) {
       { scheme: "file", language: "javascriptreact" },
       { scheme: "file", language: "typescript" },
       { scheme: "file", language: "typescriptreact" },
+      // this applies grammar and thus highlighting i think?
+      { scheme: "file", language: "vue" },
     ],
     synchronize: {
       // TODO: should this focus on `graphql-config` documents, schema and/or includes?
@@ -81,8 +83,10 @@ export function activate(context: ExtensionContext) {
           true,
         ),
         // these ignore node_modules and .git by default
+        // this is more important for language features.
+        // we don't have language features for .vue yet but we can still try to load the files
         workspace.createFileSystemWatcher(
-          "**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx}",
+          "**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx,*.vue}",
         ),
       ],
     },
@@ -128,6 +132,7 @@ export function activate(context: ExtensionContext) {
           "typescript",
           "javascriptreact",
           "typescriptreact",
+          "vue",
           "graphql",
         ],
         new GraphQLCodeLensProvider(outputChannel),

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -33,7 +33,8 @@ const statusBarActivationLanguageIds = [
   "javascript",
   "javascriptreact",
   "typescript",
-  "typescriptreact"
+  "typescriptreact",
+  "vue"
 ];
 
 function initStatusBar(


### PR DESCRIPTION
This enables the extension in vue files as well. 

Doesn't quite work yet and depends on a proper implementation of the server backend: https://github.com/graphql/graphiql/issues/1678