### PR TITLE
fix: use @urql/core instead of urql to not pull react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,14 @@
   "packages": {
     "": {
       "name": "vscode-graphql",
-      "version": "0.3.19",
+      "version": "0.3.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^7.4.1",
         "@graphql-tools/url-loader": "^7.5.2",
         "@graphql-tools/wrap": "^8.3.2",
+        "@urql/core": "^2.3.5",
         "babel-polyfill": "6.26.0",
         "capitalize": "^2.0.4",
         "dotenv": "^10.0.0",
@@ -22,7 +23,6 @@
         "graphql-tag": "^2.12.6",
         "graphql-ws": "^5.5.5",
         "node-fetch": "^2.6.6",
-        "urql": "^2.0.5",
         "vscode-languageclient": "^5.2.1",
         "ws": "^8.2.3"
       },
@@ -408,6 +408,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -516,6 +524,18 @@
       "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@urql/core": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.3.5.tgz",
+      "integrity": "sha512-kM/um4OjXmuN6NUS/FSm7dESEKWT7By1kCRCmjvU4+4uEoF1cd4TzIhQ7J1I3zbDAFhZzmThq9X0AHpbHAn3bA==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.0",
+        "wonka": "^4.0.14"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2189,18 +2209,6 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2539,6 +2547,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2859,19 +2868,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/read": {
       "version": "1.0.7",
@@ -3387,39 +3383,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
       "dev": true
-    },
-    "node_modules/urql": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/urql/-/urql-2.0.5.tgz",
-      "integrity": "sha512-UOl37CkNO1sfhw8jPihq+9NKUpTLnsRjpK7vmOVqPceqSO0rYXHOAEJp2TWDhyLjn2lYDlDlAfDaxNyK5m1FOA==",
-      "dependencies": {
-        "@urql/core": "^2.3.2",
-        "wonka": "^4.0.14"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0",
-        "react": ">= 16.8.0"
-      }
-    },
-    "node_modules/urql/node_modules/@urql/core": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.3.5.tgz",
-      "integrity": "sha512-kM/um4OjXmuN6NUS/FSm7dESEKWT7By1kCRCmjvU4+4uEoF1cd4TzIhQ7J1I3zbDAFhZzmThq9X0AHpbHAn3bA==",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.0",
-        "wonka": "^4.0.14"
-      },
-      "peerDependencies": {
-        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
-    "node_modules/urql/node_modules/@urql/core/node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
     },
     "node_modules/utf-8-validate": {
       "version": "5.0.3",
@@ -4096,6 +4059,12 @@
         }
       }
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "requires": {}
+    },
     "@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -4190,6 +4159,15 @@
       "integrity": "sha512-cyeefcUCgJlEk+hk2h3N+MqKKsPViQgF5boi9TTHSK+PoR9KWBb/C5ccPcDyAqgsbAYHTwulch725DV84+pSpg==",
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@urql/core": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.3.5.tgz",
+      "integrity": "sha512-kM/um4OjXmuN6NUS/FSm7dESEKWT7By1kCRCmjvU4+4uEoF1cd4TzIhQ7J1I3zbDAFhZzmThq9X0AHpbHAn3bA==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.1.0",
+        "wonka": "^4.0.14"
       }
     },
     "abort-controller": {
@@ -5423,15 +5401,6 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5703,7 +5672,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.11.0",
@@ -5946,16 +5916,6 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
-      }
-    },
-    "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "read": {
@@ -6342,34 +6302,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
       "dev": true
-    },
-    "urql": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/urql/-/urql-2.0.5.tgz",
-      "integrity": "sha512-UOl37CkNO1sfhw8jPihq+9NKUpTLnsRjpK7vmOVqPceqSO0rYXHOAEJp2TWDhyLjn2lYDlDlAfDaxNyK5m1FOA==",
-      "requires": {
-        "@urql/core": "^2.3.2",
-        "wonka": "^4.0.14"
-      },
-      "dependencies": {
-        "@urql/core": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/@urql/core/-/core-2.3.5.tgz",
-          "integrity": "sha512-kM/um4OjXmuN6NUS/FSm7dESEKWT7By1kCRCmjvU4+4uEoF1cd4TzIhQ7J1I3zbDAFhZzmThq9X0AHpbHAn3bA==",
-          "requires": {
-            "@graphql-typed-document-node/core": "^3.1.0",
-            "wonka": "^4.0.14"
-          },
-          "dependencies": {
-            "@graphql-typed-document-node/core": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-              "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
-              "requires": {}
-            }
-          }
-        }
-      }
     },
     "utf-8-validate": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -208,8 +208,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile -- --minify",
-    "compile": "npm run compile:server && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --external:react --format=cjs --platform=node",
-    "compile:server": "esbuild ./src/server/server.ts --bundle --outfile=out/server/server.js --external:vscode --external:react --format=cjs --platform=node",
+    "compile": "npm run compile:server && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
+    "compile:server": "esbuild ./src/server/server.ts --bundle --outfile=out/server/server.js --external:vscode --format=cjs --platform=node",
     "build": "npm run compile -- --sourcemap",
     "watch": "npm run build --watch",
     "postinstall": "node ./node_modules/vscode/bin/install",
@@ -238,6 +238,7 @@
     "@graphql-tools/load": "^7.4.1",
     "@graphql-tools/url-loader": "^7.5.2",
     "@graphql-tools/wrap": "^8.3.2",
+    "@urql/core": "^2.3.5",
     "babel-polyfill": "6.26.0",
     "capitalize": "^2.0.4",
     "dotenv": "^10.0.0",
@@ -247,7 +248,6 @@
     "graphql-tag": "^2.12.6",
     "graphql-ws": "^5.5.5",
     "node-fetch": "^2.6.6",
-    "urql": "^2.0.5",
     "vscode-languageclient": "^5.2.1",
     "ws": "^8.2.3"
   },

--- a/src/client/network-helper.ts
+++ b/src/client/network-helper.ts
@@ -13,7 +13,7 @@ import {
   createClient,
   defaultExchanges,
   subscriptionExchange,
-} from "urql"
+} from "@urql/core"
 
 import {
   ExtractedTemplateLiteral,


### PR DESCRIPTION
After #338 the extension fails to load on workspaces without react installed.

react is imported by the bundled urql package.

Using the @urql/core package instead solves the issue.

Closes #345
