### PR TITLE
Use yaml formatting for yaml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ To support language features like "go-to definition" across multiple files, plea
 
 ### Simple Example
 
-```js
-// .graphqlrc.yml
+```yaml
+# .graphqlrc.yml
 schema: "schema.graphql"
 documents: "src/**/*.{graphql,js,ts,jsx,tsx}"
 ```


### PR DESCRIPTION
JS comment breaks yaml files. Fixed comment and code block highlighting type to match contents.