### PR TITLE
Revert "Enable in vue files"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Lots of new improvements happening! We now have a [`CHANGELOG.md`](https://githu
 - go to definition support (input, enum, type)
 - outline support
 
-### `gql`/`graphql` tagged template literal support for tsx, jsx, ts, js, vue
+### `gql`/`graphql` tagged template literal support for tsx, jsx, ts, js
 
 - syntax highlighting (type, query, mutation, interface, union, enum, scalar, fragments, directives)
 - autocomplete suggestions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,8 +70,6 @@ export function activate(context: ExtensionContext) {
       { scheme: "file", language: "javascriptreact" },
       { scheme: "file", language: "typescript" },
       { scheme: "file", language: "typescriptreact" },
-      // this applies grammar and thus highlighting i think?
-      { scheme: "file", language: "vue" },
     ],
     synchronize: {
       // TODO: should this focus on `graphql-config` documents, schema and/or includes?
@@ -83,10 +81,8 @@ export function activate(context: ExtensionContext) {
           true,
         ),
         // these ignore node_modules and .git by default
-        // this is more important for language features.
-        // we don't have language features for .vue yet but we can still try to load the files
         workspace.createFileSystemWatcher(
-          "**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx,*.vue}",
+          "**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx}",
         ),
       ],
     },
@@ -132,7 +128,6 @@ export function activate(context: ExtensionContext) {
           "typescript",
           "javascriptreact",
           "typescriptreact",
-          "vue",
           "graphql",
         ],
         new GraphQLCodeLensProvider(outputChannel),

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -33,8 +33,7 @@ const statusBarActivationLanguageIds = [
   "javascript",
   "javascriptreact",
   "typescript",
-  "typescriptreact",
-  "vue"
+  "typescriptreact"
 ];
 
 function initStatusBar(


### PR DESCRIPTION
Reverts graphql/vscode-graphql#307

This PR did _not_ introduce a grammar configuration for syntax highlighting in vue files, causing a parsing error