### PR TITLE
Show the output channel when clicking on graphql status bar

### DIFF
--- a/.changeset/silly-days-march.md
+++ b/.changeset/silly-days-march.md
@@ -1,0 +1,5 @@
+---
+"vscode-graphql": patch
+---
+
+Adds support for making clicking on the graphql status item show the output channel

--- a/package.json
+++ b/package.json
@@ -194,15 +194,19 @@
     "commands": [
       {
         "command": "vscode-graphql.isDebugging",
-        "title": "VSCode GraphQL - Is Debugging?"
+        "title": "VSCode GraphQL: Is Debugging?"
       },
       {
         "command": "vscode-graphql.restart",
-        "title": "VSCode GraphQL - Manual Restart"
+        "title": "VSCode GraphQL: Manual Restart"
+      },
+      {
+        "command": "vscode-graphql.showOutputChannel",
+        "title": "VSCode GraphQL: Show output channel"
       },
       {
         "command": "vscode-graphql.contentProvider",
-        "title": "Execute GraphQL Operations"
+        "title": "VSCode GraphQL: Execute GraphQL Operations"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "escape-html": "1.0.3",
     "graphql": "15.7.2",
     "graphql-config": "4.1.0",
-    "graphql-language-service-server": "2.7.13",
+    "graphql-language-service-server": "2.7.14",
     "graphql-tag": "2.12.6",
     "graphql-ws": "5.5.5",
     "node-fetch": "2.6.7",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,6 +113,14 @@ export function activate(context: ExtensionContext) {
   )
   context.subscriptions.push(commandIsDebugging)
 
+  const commandShowOutputChannel = commands.registerCommand(
+    "vscode-graphql.showOutputChannel",
+    () => {
+      outputChannel.show()
+    },
+  )
+  context.subscriptions.push(commandShowOutputChannel)
+
   // Manage Status Bar
   context.subscriptions.push(statusBarItem)
   client.onReady().then(() => {

--- a/src/status/index.ts
+++ b/src/status/index.ts
@@ -83,12 +83,12 @@ function updateStatusBar(
   statusBarItem: StatusBarItem,
   editor: TextEditor | undefined,
 ) {
-  extensionStatus = serverRunning ? Status.RUNNING : Status.ERROR
+  extensionStatus = serverRunning ? Status.RUNNING : Status.ERROR;
 
-  const statusUI = statusBarUIElements[extensionStatus]
-  statusBarItem.text = `$(${statusUI.icon}) ${statusBarText}`
-  statusBarItem.tooltip = statusUI.tooltip
-  statusBarItem.command = "vscode-graphql.isDebugging"
+  const statusUI = statusBarUIElements[extensionStatus];
+  statusBarItem.text = `$(${statusUI.icon}) ${statusBarText}`;
+  statusBarItem.tooltip = statusUI.tooltip;
+  statusBarItem.command = "vscode-graphql.showOutputChannel";
   if ("color" in statusUI) statusBarItem.color = statusUI.color
 
   if (


### PR DESCRIPTION
As knowing whether you are in debug or not isn't too useful from a users perspective